### PR TITLE
Handle DHCPDECLINE

### DIFF
--- a/nfdhcpd/vm_net_proxy.py
+++ b/nfdhcpd/vm_net_proxy.py
@@ -615,9 +615,9 @@ class VMNetProxy(object):  # pylint: disable=R0902
             ]
             dhcp_options += [("name_server", x) for x in self.dhcp_nameservers]
 
-        elif req_type == DHCPRELEASE:
+        elif req_type in [DHCPRELEASE, DHCPDECLINE]:
             # Log and ignore
-            logging.info(" - DHCP: DHCPRELEASE from %s", binding)
+            logging.info(" - DHCP: %s from %s", DHCP_TYPES[req_type], binding)
             return
 
         # Finally, always add the server identifier and end options


### PR DESCRIPTION
So as to avoid such errors:

```
2018-03-09 06:18:24,578 INFO      - DHCP: DHCPDECLINE from hostname zaira.iema.gr, tap tap53, mac de:db:ee:6c:f0:b9, ip 62.217.127.7, eui64 2001:648:2ffc:121:dcdb:eeff:fe6c:f0b9
callback failure !
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nfdhcpd/vm_net_proxy.py", line 625, in dhcp_response
    ("message-type", resp_type),
UnboundLocalError: local variable 'resp_type' referenced before assignment
```